### PR TITLE
added n approximate queries and some additional improvements

### DIFF
--- a/Header/approximatequery.h
+++ b/Header/approximatequery.h
@@ -13,6 +13,8 @@
 #include <CGAL/Circular_arc_2.h>
 #include <CGAL/Line_arc_2.h>
 
+#include <QElapsedTimer>
+
 typedef CGAL::Exact_circular_kernel_2 CK;
 typedef CK::Circle_2 Circle_2;
 typedef CK::Line_2 Line;
@@ -28,28 +30,17 @@ class ApproximateQuery
 {
 public:
 	ApproximateQuery();
-	void setStartingPoint(const QPointF& point);
-	void setQueryPoint1(const QPointF& point);
-	void setQueryPoint2(const QPointF& point);
-
-	void clearPoints();
-
-	QPointF getStartingPoint() const;
-	QPointF getQueryPoint1() const;
-	QPointF getQueryPoint2() const;
-
-	bool isStartingPointSet() const;
-	bool isQueryPoint1Set() const;
-	bool isQueryPoint2Set() const;
 
 	void threeApproximateQuery(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon);
+	QVector<QPointF> nApproximateQuery(QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon);
+	void nEpsilonApproximateQuery(double epsilon, QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon);
 	QVector<QPointF> getThreeApproximatePath();
 
 	void epsilonApproximateQuery(double epsilon, QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon);
 
 	Line convertToCLine(QLineF& line);
 
-	QVector<QPointF> computeDiscIntersection(Circle_2& disc, QLineF& window);
+	QVector<QPointF> computeDiscIntersection(QPointF& circleCenter, Circle_2& disc, QLineF& window);
 
 	bool isPointOnLine(const QLineF& line, const QPointF& point);
 
@@ -58,6 +49,8 @@ public:
 	QVector<QPointF> generateEquallySpacedPoints(QLineF& line, double spacedDistance);
 
 	QVector<QPointF> findShortestPathAmongPairs(QVector<QPointF>& spacedPoints1, QVector<QPointF>& spacedPoints2, QPointF& startingPoint, Polygon_2& polygon);
+
+	QVector<QPointF> findShortestPathAmongVectorOfVectors(QVector<QVector<QPointF>>& spacedPointsGroups, QPointF& startingPoint, Polygon_2& polygon);
 
 	struct ApproximateResult {
 		QVector<QPointF> threeApproxPath;
@@ -71,7 +64,17 @@ public:
 		QVector<QPointF> shortestPath;
 	};
 
+	struct NApproximateResult {
+		QVector<QPointF> nApproxPath;
+		QVector<QLineF> windows;
+		double discRadius;
+		QVector<QLineF> intersectionWindows;
+		QVector<QVector<QPointF>> equallySpacedPointsGroup;
+		QVector<QPointF> shortestPath;
+	};
+
 	ApproximateQuery::ApproximateResult getApproximateResult();
+	ApproximateQuery::NApproximateResult getNApproximateResult();
 
 
 private:
@@ -91,6 +94,8 @@ private:
 	QVector<QPointF> threeApproximatePath;
 
 	ApproximateResult approximateResult;
+	NApproximateResult nApproximateResult;
+	QVector<QLineF> windowsVector;
 };
 
 #endif

--- a/Header/mainwindow.h
+++ b/Header/mainwindow.h
@@ -42,6 +42,10 @@ private:
 	QWidget* drawnLayoutWidget;
 	QWidget* givenLayoutWidget;
 
+	QStackedWidget* queryModeWidget;
+	QWidget* approximateLayoutWidget;
+	QWidget* exactLayoutWidget;
+
 
 	// Stepper control buttons
 	QPushButton* nextButton;
@@ -73,6 +77,8 @@ private:
 	int index;
 	QString queryMode;
 	QSlider* slider;
+	QSlider* epsilonSlider;
+	QSlider* intervalSlider;
 	enum RunMode {STEPPER, AUTO};
 	enum PolyMode { RANDOM, DRAW, PICK };
 
@@ -98,6 +104,8 @@ private Q_SLOTS:
 	void setupAuto();
 
 	void updateQuerySelection(PolygonWidget::QueryMode mode);
+	void setupApproximateQuery();
+	void setupExactQuery();
 	void updateRunSelection(RunMode mode);
 	void updatePolySelection(PolyMode mode);
 

--- a/Header/polygonwidget.h
+++ b/Header/polygonwidget.h
@@ -46,7 +46,8 @@ public:
 
     void startOnePointQuery(int interval, bool stepMode);
     void startTwoPointQuery(int interval, bool stepMode);
-    void startApproximateQuery(int interval, bool stepMode);
+    void startApproximateQuery(int interval, bool stepMode, double epsilon);
+    void startNApproximateQuery(int interval, bool stepMode, double epsilon);
     bool withinBoundaryCheck();
     void increaseStep();
     void decreaseStep();
@@ -111,12 +112,15 @@ private:
     bool drawOwnPolygon;
     bool fixedPoints;
 
+    QVector<QPointF> approxQueryPoints;
+
     void visualizeOnePointQuery(QPainter& painter);
     void visualizeTwoPointQuery(QPainter& painter);
     void visualizeIntersection(QPainter& painter);
     void visualizeDomination(QPainter& painter);
     void visualizeGeneralCase(QPainter& painter);
     void visualizeApprox(QPainter& painter);
+    void visualizeNApprox(QPainter& painter);
     // Q_SLOT void startSingleQuery();
     QString errorMessage;
 
@@ -128,6 +132,7 @@ private:
     TwoPointQuery::IntersectionResult resultIntersection;
     TwoPointQuery::DominationResult resultDomination;
     ApproximateQuery::ApproximateResult resultApprox;
+    ApproximateQuery::NApproximateResult resultNApprox;
 };
 
 #endif // POLYGONWIDGET_H

--- a/Header/shortestpath.h
+++ b/Header/shortestpath.h
@@ -48,7 +48,11 @@ public:
     void createMesh(const Polygon_2 &polygon);
     const Surface_mesh &getMesh() const;
     void clearTree();
+    void clearMesh();
+    bool is_point_on_polygon_edge(const Polygon_2& polygon, const Point_2& point);
     QVector<QPointF> findShortestPath(QPointF source2D, QPointF query2D, const Polygon_2 &polygon);
+    double findShortestPathLength(QPointF source2D, QPointF query2D, const Polygon_2& polygon);
+    Point_2 snapQueryInsidePolygon(QPointF& queryPoint, const Polygon_2& polygon);
     QVector<QPointF> point3VectorToQtVector(std::vector<Point_3>& points);
     const Point_2 &getPenultimate(const std::vector<Point_3> &path, const Polygon_2 &polygon) const;
     QVector<QPointF> reversePath(QVector<QPointF>& path);

--- a/Source/approximatequery.cpp
+++ b/Source/approximatequery.cpp
@@ -4,61 +4,6 @@ ApproximateQuery::ApproximateQuery()
 {
 }
 
-void ApproximateQuery::setStartingPoint(const QPointF& point)
-{
-	m_startingPoint = point;
-	m_startSelected = true;
-}
-
-void ApproximateQuery::setQueryPoint1(const QPointF& point)
-{
-	m_queryPoint1 = point;
-	m_query1Selected = true;
-}
-
-void ApproximateQuery::setQueryPoint2(const QPointF& point)
-{
-	m_queryPoint2 = point;
-	m_query2Selected = true;
-}
-
-void ApproximateQuery::clearPoints()
-{
-	m_startSelected = false;
-	m_query1Selected = false;
-	m_query2Selected = false;
-}
-
-QPointF ApproximateQuery::getStartingPoint() const
-{
-	return m_startingPoint;
-}
-
-QPointF ApproximateQuery::getQueryPoint1() const
-{
-	return m_queryPoint1;
-}
-
-QPointF ApproximateQuery::getQueryPoint2() const
-{
-	return m_queryPoint2;
-}
-
-bool ApproximateQuery::isStartingPointSet() const
-{
-	return m_startSelected;
-}
-
-bool ApproximateQuery::isQueryPoint1Set() const
-{
-	return m_query1Selected;
-}
-
-bool ApproximateQuery::isQueryPoint2Set() const
-{
-	return m_query2Selected;
-}
-
 void ApproximateQuery::threeApproximateQuery(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon) {
 	threeApproximatePath.clear();
 	m_onePointHandler.executeOnePointQuery(startingPoint, queryPoint1, polygon);
@@ -73,7 +18,88 @@ void ApproximateQuery::threeApproximateQuery(QPointF& startingPoint, QPointF& qu
 
 QVector<QPointF> ApproximateQuery::getThreeApproximatePath() { return threeApproximatePath; }
 
+QVector<QPointF> ApproximateQuery::nApproximateQuery(QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon) {
+	windowsVector.clear();
+	QVector<QPointF> nApproximatePath;
+
+	if (queryPoints.size() < 1) {
+		return nApproximatePath;
+	}
+
+	OnePointQuery::QueryResult tempQueryResult;
+
+	for (QPointF point : queryPoints) {
+		m_onePointHandler.executeOnePointQuery(startingPoint, point, polygon);
+		tempQueryResult = m_onePointHandler.getResult();
+		windowsVector.append(tempQueryResult.window);
+		nApproximatePath.append(tempQueryResult.optimalPath);
+		if (point != queryPoints.rbegin()[0]) {
+			nApproximatePath.append(m_shortestPathHandler.reversePath(tempQueryResult.optimalPath));
+		}
+	}
+
+	return nApproximatePath;
+}
+
+void ApproximateQuery::nEpsilonApproximateQuery(double epsilon, QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon) {
+	if (queryPoints.size() < 1) {
+		return;
+	}
+
+	QElapsedTimer timer;
+	timer.start();
+
+	// 1.
+	QVector<QPointF> nApproximatePath = nApproximateQuery(startingPoint, queryPoints, polygon);
+	nApproximateResult.nApproxPath = nApproximatePath;
+	double nApproximatePathLength = m_twoPointHandler.calculatePathLength(nApproximatePath);
+	const int sizeOfN = queryPoints.size() * 2 - 1;
+	std::cout << "size n: " << sizeOfN << "\n";
+
+	// 2.
+	nApproximateResult.windows = windowsVector;
+
+	// 3.
+	Point startingPointC = Point(startingPoint.x(), startingPoint.y());
+	double radius = 2 * nApproximatePathLength;
+	nApproximateResult.discRadius = radius;
+	double squaredRadius = radius * radius;
+	Circle_2 disc = Circle_2(startingPointC, squaredRadius, CGAL::COUNTERCLOCKWISE);
+	QVector<QLineF> intersectionWindowsVector;
+	QVector<QPointF> discWindowIntersections;
+	for (QLineF window : windowsVector) {
+		discWindowIntersections = computeDiscIntersection(startingPoint, disc, window);
+		if (discWindowIntersections.size() == 2) {
+			intersectionWindowsVector.append(QLineF(discWindowIntersections[0], discWindowIntersections[1]));
+		}
+	}
+	nApproximateResult.intersectionWindows = intersectionWindowsVector;
+
+	// 4.
+	double const delta = epsilon * nApproximatePathLength / sizeOfN;
+	double const spacedDistance = delta / sizeOfN;
+	QVector<QVector<QPointF>> spacedPointsVectorGroup;
+	for (QLineF intersectionWindow : intersectionWindowsVector) {
+		spacedPointsVectorGroup.append(generateEquallySpacedPoints(intersectionWindow, spacedDistance));
+
+	}
+
+	nApproximateResult.equallySpacedPointsGroup = spacedPointsVectorGroup;
+
+	// 5.
+	QVector<QPointF> shortestPath = findShortestPathAmongVectorOfVectors(spacedPointsVectorGroup, startingPoint, polygon);
+	nApproximateResult.shortestPath = shortestPath;
+
+	qint64 elapsedTime = timer.elapsed();
+	std::cout << "epsilonApproximateQuery completed in" << elapsedTime << " ms \n";
+}
+
+ApproximateQuery::NApproximateResult ApproximateQuery::getNApproximateResult() { return nApproximateResult; }
+
 void ApproximateQuery::epsilonApproximateQuery(double epsilon, QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon) {
+	QElapsedTimer timer;
+	timer.start();
+
 	// 1.
 	threeApproximateQuery(startingPoint, queryPoint1, queryPoint2, polygon);
 	QVector<QPointF> threeApproximatePath = getThreeApproximatePath();
@@ -93,8 +119,8 @@ void ApproximateQuery::epsilonApproximateQuery(double epsilon, QPointF& starting
 	approximateResult.discRadius = radius;
 	double squaredRadius = radius * radius;
 	Circle_2 disc = Circle_2(startingPointC, squaredRadius, CGAL::COUNTERCLOCKWISE);
-	QVector<QPointF> intersectionsVector1 = computeDiscIntersection(disc, window1);
-	QVector<QPointF> intersectionsVector2 = computeDiscIntersection(disc, window2);
+	QVector<QPointF> intersectionsVector1 = computeDiscIntersection(startingPoint, disc, window1);
+	QVector<QPointF> intersectionsVector2 = computeDiscIntersection(startingPoint, disc, window2);
 	QLineF intersectionWindow1;
 	QLineF intersectionWindow2;
 	if (intersectionsVector1.size() == 2) {
@@ -117,6 +143,9 @@ void ApproximateQuery::epsilonApproximateQuery(double epsilon, QPointF& starting
 	// 5.
 	QVector<QPointF> shortestPath = findShortestPathAmongPairs(spacedPoints1, spacedPoints2, startingPoint, polygon);
 	approximateResult.shortestPath = shortestPath;
+
+	qint64 elapsedTime = timer.elapsed();
+	std::cout << "epsilonApproximateQuery completed in" << elapsedTime << " ms \n";
 }
 
 ApproximateQuery::ApproximateResult ApproximateQuery::getApproximateResult() { return approximateResult; }
@@ -131,7 +160,7 @@ Line ApproximateQuery::convertToCLine(QLineF& line) {
 	return Line(firstEndpointC, secondEndpointC);
 }
 
-QVector<QPointF> ApproximateQuery::computeDiscIntersection(Circle_2& disc, QLineF& window) {
+QVector<QPointF> ApproximateQuery::computeDiscIntersection(QPointF& circleCenter, Circle_2& disc, QLineF& window) {
 	Line windowC = convertToCLine(window);
 	QVector<QPointF> intersectionsQ;
 	std::vector<var> intersections;
@@ -154,7 +183,7 @@ QVector<QPointF> ApproximateQuery::computeDiscIntersection(Circle_2& disc, QLine
 			if (isPointOnLine(window, point)) {
 				intersectionsQ.append(point);
 			}
-			
+
 
 		}
 		// Case 2: Intersection is a Circular_arc_2 (overlap of circular arcs)
@@ -183,7 +212,7 @@ QVector<QPointF> ApproximateQuery::computeDiscIntersection(Circle_2& disc, QLine
 		intersectionsQ.append(window.p2());
 	}
 	else if (intersectionsQ.size() == 1) {
-		if (calculatePointToPointDistance(getStartingPoint(), window.p1()) <= calculatePointToPointDistance(getStartingPoint(), window.p2())) {
+		if (calculatePointToPointDistance(circleCenter, window.p1()) <= calculatePointToPointDistance(circleCenter, window.p2())) {
 			intersectionsQ.append(window.p1());
 		}
 		else {
@@ -270,7 +299,6 @@ QVector<QPointF> ApproximateQuery::findShortestPathAmongPairs(
 {
 	QVector<QPointF> bestPath;  // Store the shortest path
 	double minPathLength = std::numeric_limits<double>::max();  // Initialize to infinity
-	m_shortestPathHandler.createMesh(polygon);
 
 	// Iterate over all pairs of points (u, v)
 	for (QPointF& u : spacedPoints1) {
@@ -301,4 +329,134 @@ QVector<QPointF> ApproximateQuery::findShortestPathAmongPairs(
 
 	return bestPath;
 }
+
+QVector<QPointF> ApproximateQuery::findShortestPathAmongVectorOfVectors(
+	QVector<QVector<QPointF>>& spacedPointsGroups,
+	QPointF& startingPoint,
+	Polygon_2& polygon)
+{
+	auto computeShortestPathLength = [&](const QPointF& p1, const QPointF& p2) -> double {
+		return m_shortestPathHandler.findShortestPathLength(p1, p2, polygon);
+		};
+
+	int numGroups = spacedPointsGroups.size();
+	QVector<int> bestWindowOrder;
+	double minTotalDistance = std::numeric_limits<double>::max();
+
+	QVector<int> indices(numGroups, 0);  // To track indices of selected points in each group.
+	bool done = false;
+
+	while (!done) {
+		QVector<QPointF> currentPath;
+		QVector<int> currentWindowOrder;  // To track the current window order.
+		currentPath.append(startingPoint);
+
+		// Append selected points and their window indices.
+		for (int i = 0; i < numGroups; ++i) {
+			currentPath.append(spacedPointsGroups[i][indices[i]]);
+			currentWindowOrder.append(i);  // Record the window index.
+		}
+
+		// Compute the total path length for the current combination.
+		double totalDistance = 0.0;
+		for (int i = 0; i < currentPath.size() - 1; ++i) {
+			totalDistance += computeShortestPathLength(currentPath[i], currentPath[i + 1]);
+		}
+
+		// Update the best path and window order if a shorter one is found.
+		if (totalDistance < minTotalDistance) {
+			minTotalDistance = totalDistance;
+			bestWindowOrder = currentWindowOrder;
+		}
+
+		// Increment indices to generate the next combination.
+		for (int i = 0; i < numGroups; ++i) {
+			indices[i]++;
+			if (indices[i] < spacedPointsGroups[i].size()) {
+				break;
+			}
+			indices[i] = 0;
+			if (i == numGroups - 1) {
+				done = true;
+			}
+		}
+	}
+
+	// Compute the actual shortest path using the best window order.
+	QVector<QPointF> bestPath;
+	bestPath.append(startingPoint);
+
+	QPointF currentPoint = startingPoint;
+	for (int windowIndex : bestWindowOrder) {
+		std::cout << windowIndex << ", ";
+		// Find the closest point from the current window.
+		QPointF nextPoint = spacedPointsGroups[windowIndex][indices[windowIndex]];
+
+		// Compute the actual shortest path between currentPoint and nextPoint.
+		QVector<QPointF> segmentPath = m_shortestPathHandler.findShortestPath(currentPoint, nextPoint, polygon);
+
+		// Append the segment path to the best path, excluding the first point to avoid duplication.
+		if (!bestPath.isEmpty()) {
+			segmentPath.pop_front();
+		}
+		bestPath.append(segmentPath);
+
+		// Update currentPoint for the next iteration.
+		currentPoint = nextPoint;
+	}
+	std::cout << "\n";
+
+	return bestPath;
+}
+
+/*
+QVector<QPointF> ApproximateQuery::findShortestPathAmongVectorOfVectors(
+	QVector<QVector<QPointF>>& spacedPointsGroups,
+	QPointF& startingPoint,
+	Polygon_2& polygon)
+{
+	QVector<QPointF> bestPath;  // Store the shortest path
+	std::vector<int> visitedIndices;
+
+	double minPathLength = std::numeric_limits<double>::max();  // Initialize to infinity
+
+	// Iterate over all unique pairs of QVector<QPointF>
+	int numGroups = spacedPointsGroups.size();
+	for (int i = 0; i < numGroups; ++i) {
+		for (int j = i + 1; j < numGroups; ++j) {
+			QVector<QPointF>& spacedPoints1 = spacedPointsGroups[i];
+			QVector<QPointF>& spacedPoints2 = spacedPointsGroups[j];
+
+			// Iterate over all pairs of points (u, v) from the two groups
+			for (QPointF& u : spacedPoints1) {
+				for (QPointF& v : spacedPoints2) {
+					// Path visiting u first, then v
+					QVector<QPointF> path1 = m_shortestPathHandler.findShortestPath(startingPoint, u, polygon);
+					QVector<QPointF> pathToV1 = m_shortestPathHandler.findShortestPath(u, v, polygon);
+					path1.append(pathToV1);
+					double pathLength1 = m_twoPointHandler.calculatePathLength(path1);
+
+					// Path visiting v first, then u
+					QVector<QPointF> path2 = m_shortestPathHandler.findShortestPath(startingPoint, v, polygon);
+					QVector<QPointF> pathToU2 = m_shortestPathHandler.findShortestPath(v, u, polygon);
+					path2.append(pathToU2);
+					double pathLength2 = m_twoPointHandler.calculatePathLength(path2);
+
+					// Choose the shorter path
+					if (pathLength1 < minPathLength) {
+						minPathLength = pathLength1;
+						bestPath = path1;
+					}
+					if (pathLength2 < minPathLength) {
+						minPathLength = pathLength2;
+						bestPath = path2;
+					}
+				}
+			}
+		}
+	}
+
+	return bestPath;
+}
+*/
 

--- a/Source/onepointquery.cpp
+++ b/Source/onepointquery.cpp
@@ -176,6 +176,10 @@ void OnePointQuery::shootRayExtended(const QPointF& point1, const QPointF& point
 				continue;
 			}
 
+			if (polygon.has_on_boundary(*p)) {
+				std::cout << "aaaa \n";
+			}
+
 			// Compute the distance from the source to this intersection point
 			K::FT distance = CGAL::squared_distance(source, *p);
 
@@ -375,8 +379,6 @@ void OnePointQuery::executeOnePointQuery(QPointF& startingPoint, QPointF& queryP
 		return;
 	}
 
-	m_shortestPathHandler.createMesh(polygon);
-
 	// Find shortest path from s to q
 	QVector<QPointF> pathStartToQuery = m_shortestPathHandler.findShortestPath(startingPoint, queryPoint, polygon);
 	result.pathStartToQuery = pathStartToQuery;
@@ -394,8 +396,7 @@ void OnePointQuery::executeOnePointQuery(QPointF& startingPoint, QPointF& queryP
 	// construct the funnel through its sides
 	QVector<QPointF> pathRootToA = m_shortestPathHandler.findShortestPath(lca, a, polygon);
 	result.pathRootToA = pathRootToA;
-	QVector<QPointF> pathBtoRoot = m_shortestPathHandler.findShortestPath(b, lca, polygon);
-	QVector<QPointF> pathRootToB = m_shortestPathHandler.reversePath(pathBtoRoot); // need to reverse to get the path from b to lca
+	QVector<QPointF> pathRootToB = m_shortestPathHandler.findShortestPath(lca, b, polygon);
 	result.pathRootToB = pathRootToB;
 
 	QPointF c = computeOptimalPoint(pathRootToA, pathRootToB, lca, window);

--- a/Source/shortestpath.cpp
+++ b/Source/shortestpath.cpp
@@ -1,158 +1,225 @@
 #include "shortestpath.h"
 
 ShortestPath::ShortestPath()
-    : pointsSet(false)
+	: pointsSet(false)
 {
 }
 
-void ShortestPath::createMesh(const Polygon_2 &polygon)
+void ShortestPath::createMesh(const Polygon_2& polygon)
 {
-    mesh.clear();
-    cdt.clear();
-    cdt.insert_constraint(polygon.vertices_begin(), polygon.vertices_end(), true);
-    assert(cdt.is_valid());
+	mesh.clear();
+	cdt.clear();
+	cdt.insert_constraint(polygon.vertices_begin(), polygon.vertices_end(), true);
+	assert(cdt.is_valid());
 
-    std::unordered_map<CDT::Face_handle, bool> in_domain_map;
-    boost::associative_property_map<std::unordered_map<CDT::Face_handle, bool>>
-        in_domain(in_domain_map);
+	std::unordered_map<CDT::Face_handle, bool> in_domain_map;
+	boost::associative_property_map<std::unordered_map<CDT::Face_handle, bool>>
+		in_domain(in_domain_map);
 
-    // Mark facets that are inside the domain bounded by the polygon
-    CGAL::mark_domain_in_triangulation(cdt, in_domain);
+	// Mark facets that are inside the domain bounded by the polygon
+	CGAL::mark_domain_in_triangulation(cdt, in_domain);
 
-    std::map<CDT::Vertex_handle, Surface_mesh::Vertex_index> vertexMap;
+	std::map<CDT::Vertex_handle, Surface_mesh::Vertex_index> vertexMap;
 
-    // Add vertices to the Surface_mesh
-    for (CDT::Finite_vertices_iterator vit = cdt.finite_vertices_begin(); vit != cdt.finite_vertices_end(); ++vit)
-    {
-        Point_3 p3(vit->point().x(), vit->point().y(), 0);
-        vertexMap[vit] = mesh.add_vertex(p3);
-    }
+	// Add vertices to the Surface_mesh
+	for (CDT::Finite_vertices_iterator vit = cdt.finite_vertices_begin(); vit != cdt.finite_vertices_end(); ++vit)
+	{
+		Point_3 p3(vit->point().x(), vit->point().y(), 0);
+		vertexMap[vit] = mesh.add_vertex(p3);
+	}
 
-    // Add faces (triangles) to the Surface_mesh only if they are inside the polygon
-    for (CDT::Finite_faces_iterator fit = cdt.finite_faces_begin(); fit != cdt.finite_faces_end(); ++fit)
-    {
-        // Skip infinite faces and faces outside the domain
-        if (cdt.is_infinite(fit) || !in_domain[fit])
-            continue;
+	// Add faces (triangles) to the Surface_mesh only if they are inside the polygon
+	for (CDT::Finite_faces_iterator fit = cdt.finite_faces_begin(); fit != cdt.finite_faces_end(); ++fit)
+	{
+		// Skip infinite faces and faces outside the domain
+		if (cdt.is_infinite(fit) || !in_domain[fit])
+			continue;
 
-        // Get vertices of the triangle
-        Surface_mesh::Vertex_index v0 = vertexMap[fit->vertex(0)];
-        Surface_mesh::Vertex_index v1 = vertexMap[fit->vertex(1)];
-        Surface_mesh::Vertex_index v2 = vertexMap[fit->vertex(2)];
+		// Get vertices of the triangle
+		Surface_mesh::Vertex_index v0 = vertexMap[fit->vertex(0)];
+		Surface_mesh::Vertex_index v1 = vertexMap[fit->vertex(1)];
+		Surface_mesh::Vertex_index v2 = vertexMap[fit->vertex(2)];
 
-        // Add the triangular face to the mesh
-        mesh.add_face(v0, v1, v2);
-    }
+		// Add the triangular face to the mesh
+		mesh.add_face(v0, v1, v2);
+	}
 }
 
-const Surface_mesh &ShortestPath::getMesh() const
+const Surface_mesh& ShortestPath::getMesh() const
 {
-    return mesh;
+	return mesh;
 }
 
 void ShortestPath::clearTree() {
-    tree.clear();
+	tree.clear();
 }
 
-QVector<QPointF> ShortestPath::findShortestPath(QPointF source2D, QPointF query2D, const Polygon_2 &polygon)
+void ShortestPath::clearMesh() {
+	mesh.clear();
+}
+
+bool ShortestPath::is_point_on_polygon_edge(const Polygon_2& polygon, const Point_2& point) {
+	for (auto edge = polygon.edges_begin(); edge != polygon.edges_end(); ++edge) {
+		if (CGAL::collinear_are_ordered_along_line(edge->source(), point, edge->target())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+QVector<QPointF> ShortestPath::findShortestPath(QPointF source2D, QPointF query2D, const Polygon_2& polygon)
 {
-    points.clear();
-    shortestPath.clear();
+	points.clear();
+	shortestPath.clear();
 
-    // construct a shortest path query object and add a source point
-    Surface_mesh_shortest_path shortest_paths(mesh);
+	if (mesh.is_empty()) {
+		createMesh(polygon);
+	}
 
-    // Convert source and query points to 3D points
-    const Point_3 source = Point_3(source2D.x(), source2D.y(), 0);
-    const Point_3 query = Point_3(query2D.x(), query2D.y(), 0);
-    // Build the AABB tree for the mesh
-    Face_location source_loc = shortest_paths.locate<AABB_face_graph_traits>(source);
+	Point_2 query2 = snapQueryInsidePolygon(query2D, polygon);
 
-    // Add the source point
-    shortest_paths.add_source_point(source_loc.first, source_loc.second);
-    
-    Face_location query_loc = shortest_paths.locate<AABB_face_graph_traits>(query);
+	// construct a shortest path query object and add a source point
+	Surface_mesh_shortest_path shortest_paths(mesh);
 
-    // Collect shortest path points
-    shortest_paths.shortest_path_points_to_source_points(query_loc.first, query_loc.second, std::back_inserter(points));
+	// Convert source and query points to 3D points
+	const Point_3 source = Point_3(source2D.x(), source2D.y(), 0);
+	const Point_3 query = Point_3(query2.x(), query2.y(), 0);
+	// Build the AABB tree for the mesh
+	Face_location source_loc = shortest_paths.locate<AABB_face_graph_traits>(source);
 
-    std::set<Point_2> polygonVertices;
-    for (auto vertex = polygon.vertices_begin(); vertex != polygon.vertices_end(); ++vertex) {
-        polygonVertices.insert(*vertex);
-    }
+	// Add the source point
+	shortest_paths.add_source_point(source_loc.first, source_loc.second);
 
-    for (int i = 0; i < points.size(); i++) {
-        Point_2 currentPoint(points[i].x(), points[i].y());
-        if (polygonVertices.count(currentPoint) > 0 || i == 0 || i == points.size() - 1) {
-            shortestPath.push_back(points[i]);
-        }
-    }
-    
-    QVector<QPointF> shortestPathQt = point3VectorToQtVector(shortestPath);
-    return reversePath(shortestPathQt);
+	Face_location query_loc = shortest_paths.locate<AABB_face_graph_traits>(query);
+
+	// Collect shortest path points
+	shortest_paths.shortest_path_points_to_source_points(query_loc.first, query_loc.second, std::back_inserter(points));
+
+	std::set<Point_2> polygonVertices;
+	for (auto vertex = polygon.vertices_begin(); vertex != polygon.vertices_end(); ++vertex) {
+		polygonVertices.insert(*vertex);
+	}
+
+	for (int i = 0; i < points.size(); i++) {
+		Point_2 currentPoint(points[i].x(), points[i].y());
+		if (polygonVertices.count(currentPoint) > 0 || i == 0 || i == points.size() - 1) {
+			shortestPath.push_back(points[i]);
+		}
+	}
+
+	QVector<QPointF> shortestPathQt = point3VectorToQtVector(shortestPath);
+	return reversePath(shortestPathQt);
+}
+
+double ShortestPath::findShortestPathLength(QPointF source2D, QPointF query2D, const Polygon_2& polygon)
+{
+	if (mesh.is_empty()) {
+		createMesh(polygon);
+	}
+
+	Point_2 query2 = snapQueryInsidePolygon(query2D, polygon);
+
+	// Create shortest path query object and add a source point
+	Surface_mesh_shortest_path shortest_paths(mesh);
+
+	// Convert source and query points to 3D points
+	const Point_3 source = Point_3(source2D.x(), source2D.y(), 0);
+	const Point_3 query = Point_3(query2.x(), query2.y(), 0);
+
+	// Locate the source on the mesh
+	Face_location source_loc = shortest_paths.locate<AABB_face_graph_traits>(source);
+	shortest_paths.add_source_point(source_loc.first, source_loc.second);
+
+	// Locate the query on the mesh
+	Face_location query_loc = shortest_paths.locate<AABB_face_graph_traits>(query);
+
+	// Return the shortest distance directly
+	return shortest_paths.shortest_distance_to_source_points(query_loc.first, query_loc.second).first;
+}
+
+Point_2 ShortestPath::snapQueryInsidePolygon(QPointF& queryPoint, const Polygon_2& polygon) {
+	Point_2 query = Point_2(queryPoint.x(), queryPoint.y());
+
+	const float epsilon = 0.000001;
+	// TODO: Add more finer directions (i.e. diagonals)
+	//if (is_point_on_polygon_edge(polygon, query)) {
+	if (polygon.has_on_bounded_side(Point_2(query.x() + epsilon, query.y()))) {
+		query = Point_2(query.x() + epsilon, query.y());
+	}
+	else if (polygon.has_on_bounded_side(Point_2(query.x() - epsilon, query.y()))) {
+		query = Point_2(query.x() - epsilon, query.y());
+	}
+	else if (polygon.has_on_bounded_side(Point_2(query.x(), query.y() + epsilon))) {
+		query = Point_2(query.x(), query.y() + epsilon);
+	}
+	else if (polygon.has_on_bounded_side(Point_2(query.x(), query.y() - epsilon))) {
+		query = Point_2(query.x(), query.y() - epsilon);
+	}
+	//}
+
+	return query;
 }
 
 QVector<QPointF> ShortestPath::point3VectorToQtVector(std::vector<Point_3>& points)
 {
-    QVector<QPointF> qtPoints;
-    qtPoints.reserve(points.size());
+	QVector<QPointF> qtPoints;
+	qtPoints.reserve(points.size());
 
-    for (const auto& point : points)
-    {
-        qtPoints.append(QPointF(point.x(), point.y()));
-    }
+	for (const auto& point : points)
+	{
+		qtPoints.append(QPointF(point.x(), point.y()));
+	}
 
-    return qtPoints;
+	return qtPoints;
 }
 
-const Point_2 &ShortestPath::getPenultimate(const std::vector<Point_3> &path, const Polygon_2 &polygon) const
+const Point_2& ShortestPath::getPenultimate(const std::vector<Point_3>& path, const Polygon_2& polygon) const
 {
-    // Iterate over the points vector, starting from the second element (index 1)
-    for (int i = path.size() - 1; i >= 0 ; i--)
-    {
-        // Convert each point to a Point_2
-        Point_2 penultimate(path[i].x(), path[i].y());
+	// Iterate over the points vector, starting from the second element (index 1)
+	for (int i = path.size() - 1; i >= 0; i--)
+	{
+		// Convert each point to a Point_2
+		Point_2 penultimate(path[i].x(), path[i].y());
 
-        // Check if this point lies on the boundary of the polygon
-        if (polygon.has_on_boundary(penultimate))
-        {
-            return penultimate; // Return the first point found on the boundary
-        }
-    }
+		// Check if this point lies on the boundary of the polygon
+		if (polygon.has_on_boundary(penultimate))
+		{
+			return penultimate; // Return the first point found on the boundary
+		}
+	}
 
-    // Handle case where no point on the boundary was found
-    //throw std::runtime_error("No point on the polygon boundary was found in the path.");
-    Point_3 lastPoint_3 = path.back();
-    return Point_2(lastPoint_3.x(), lastPoint_3.y());
+	// Handle case where no point on the boundary was found
+	//throw std::runtime_error("No point on the polygon boundary was found in the path.");
+	Point_3 lastPoint_3 = path.back();
+	return Point_2(lastPoint_3.x(), lastPoint_3.y());
 }
 
 QVector<QPointF> ShortestPath::reversePath(QVector<QPointF>& path)
 {
-    std::reverse(path.begin(), path.end());
-    return path;
+	std::reverse(path.begin(), path.end());
+	return path;
 }
 
 QPointF ShortestPath::getLCA(QPointF& start, QPointF& a, QPointF& b, Polygon_2& polygon)
 {
-    QVector<QPointF> path1 = findShortestPath(start, a, polygon);
-    QVector<QPointF> path2 = findShortestPath(b, start, polygon);
-    path2 = reversePath(path2);
+	QVector<QPointF> path1 = findShortestPath(start, a, polygon);
+	QVector<QPointF> path2 = findShortestPath(start, b, polygon);
 
-    QPointF lca;
+	QPointF lca;
 
-    // Iterate over both paths until they diverge
-    size_t minLength = std::min(path1.size(), path2.size());
-    for (size_t i = 0; i < minLength; ++i)
-    {
-        if (path1[i] == path2[i])
-        {
-            lca = path1[i]; // Update LCA to the current common point
-        }
-        else
-        {
-            break; // Paths diverge, stop the search
-        }
-    }
+	// Iterate over both paths until they diverge
+	size_t minLength = std::min(path1.size(), path2.size());
+	for (size_t i = 0; i < minLength; ++i)
+	{
+		if (path1[i] == path2[i])
+		{
+			lca = path1[i]; // Update LCA to the current common point
+		}
+		else
+		{
+			break; // Paths diverge, stop the search
+		}
+	}
 
-    return lca;
+	return lca;
 }

--- a/Source/twopointquery.cpp
+++ b/Source/twopointquery.cpp
@@ -22,16 +22,13 @@ QVector<QPointF> TwoPointQuery::shortestPathToSegment(QPointF start, QLineF segm
 	QPointF a = segment.p1();
 	QPointF b = segment.p2();
 
-	m_shortestPathHandler.createMesh(polygon); // TODO: give mesh and not recalculate it
-
 	QPointF lca = m_shortestPathHandler.getLCA(start, a, b, polygon);
 
-	QVector<QPointF> pathRA = m_shortestPathHandler.findShortestPath(lca, a, polygon);
-	QVector<QPointF> pathBR = m_shortestPathHandler.findShortestPath(b, lca, polygon); // makes the calculations more consistent
-	QVector<QPointF> pathRB = m_shortestPathHandler.reversePath(pathBR); // need to reverse to get the path from b to lca
+	QVector<QPointF> pathRootToA = m_shortestPathHandler.findShortestPath(lca, a, polygon);
+	QVector<QPointF> pathRootToB = m_shortestPathHandler.findShortestPath(lca, b, polygon); 
 
 
-	const QPointF c = m_onePointHandler.computeOptimalPoint(pathRA, pathRB, lca, segment);
+	const QPointF c = m_onePointHandler.computeOptimalPoint(pathRootToA, pathRootToB, lca, segment);
 
 	const QVector<QPointF> pathSC = m_shortestPathHandler.findShortestPath(start, c, polygon);
 	return pathSC;
@@ -890,7 +887,6 @@ void TwoPointQuery::executeTwoPointQuery(QPointF& startingPoint, QPointF& queryP
 		return;
 	}
 
-	m_shortestPathHandler.createMesh(polygon);
 
 	QVector<QPointF> shortestPathSQ1 = m_shortestPathHandler.findShortestPath(startingPoint, queryPoint1, polygon);
 	QVector<QPointF> shortestPathSQ2 = m_shortestPathHandler.findShortestPath(startingPoint, queryPoint2, polygon);
@@ -1072,8 +1068,7 @@ void TwoPointQuery::generalCase(QPointF& startingPoint, QLineF& window1, QLineF&
 	QPointF b2 = window2.p2();
 
 	QVector<QPointF> pathStartToA1 = m_shortestPathHandler.findShortestPath(startingPoint, a1, polygon);
-	QVector<QPointF> pathB1ToStart = m_shortestPathHandler.findShortestPath(b1, startingPoint, polygon);
-	QVector<QPointF> pathStartToB1 = m_shortestPathHandler.reversePath(pathB1ToStart);
+	QVector<QPointF> pathStartToB1 = m_shortestPathHandler.findShortestPath(startingPoint, b1, polygon);
 
 	QPointF penultimatePointSToA1 = pathStartToA1.begin()[1];
 	QPointF penultimatePointSToB1 = pathStartToB1.begin()[1];
@@ -1091,8 +1086,7 @@ void TwoPointQuery::generalCase(QPointF& startingPoint, QLineF& window1, QLineF&
 
 	QVector<QPointF> funnelSideA = m_shortestPathHandler.findShortestPath(funnelRoot, a1, polygon);
 	resultGeneral.funnelSideA = funnelSideA;
-	QVector<QPointF> funnelSideBReversed = m_shortestPathHandler.findShortestPath(b1, funnelRoot, polygon);
-	QVector<QPointF> funnelSideB = m_shortestPathHandler.reversePath(funnelSideBReversed);
+	QVector<QPointF> funnelSideB = m_shortestPathHandler.findShortestPath(funnelRoot, b1, polygon);
 	resultGeneral.funnelSideB = funnelSideB;
 
 	constructHourglass(window1, window2, polygon);


### PR DESCRIPTION
- Added the ability to query a variable amount of points in the approximate query
- Added slider for user control of the interval between the steps in autorun 
- Added slider for user control of the epsilon value of the approximate query
- Improved the speed of shortest path calculations by only calculating the mesh once for the polygon
- Added a function to directly calculate the length of the shortest path, making calculations more efficient that only need length
- Worked out the issue of the shortest path not calculating properly