### PR TITLE
misc fixes 1

### DIFF
--- a/Header/approximatequery.h
+++ b/Header/approximatequery.h
@@ -31,12 +31,12 @@ class ApproximateQuery
 public:
 	ApproximateQuery();
 
-	void threeApproximateQuery(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon);
-	QVector<QPointF> nApproximateQuery(QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon);
-	void nEpsilonApproximateQuery(double epsilon, QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon);
+	void threeApproximateQuery(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon, Surface_mesh& mesh);
+	QVector<QPointF> nApproximateQuery(QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon, Surface_mesh& mesh);
+	void nEpsilonApproximateQuery(double epsilon, QPointF& startingPoint, QVector<QPointF>& queryPoints, Polygon_2& polygon, Surface_mesh& mesh);
 	QVector<QPointF> getThreeApproximatePath();
 
-	void epsilonApproximateQuery(double epsilon, QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon);
+	void epsilonApproximateQuery(double epsilon, QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon, Surface_mesh& mesh);
 
 	Line convertToCLine(QLineF& line);
 
@@ -48,9 +48,9 @@ public:
 
 	QVector<QPointF> generateEquallySpacedPoints(QLineF& line, double spacedDistance);
 
-	QVector<QPointF> findShortestPathAmongPairs(QVector<QPointF>& spacedPoints1, QVector<QPointF>& spacedPoints2, QPointF& startingPoint, Polygon_2& polygon);
+	QVector<QPointF> findShortestPathAmongPairs(QVector<QPointF>& spacedPoints1, QVector<QPointF>& spacedPoints2, QPointF& startingPoint, Polygon_2& polygon, Surface_mesh& mesh);
 
-	QVector<QPointF> findShortestPathAmongVectorOfVectors(QVector<QVector<QPointF>>& spacedPointsGroups, QPointF& startingPoint, Polygon_2& polygon);
+	QVector<QPointF> findShortestPathAmongVectorOfVectors(QVector<QVector<QPointF>>& spacedPointsGroups, QPointF& startingPoint, Polygon_2& polygon, Surface_mesh& mesh);
 
 	struct ApproximateResult {
 		QVector<QPointF> threeApproxPath;

--- a/Header/common.h
+++ b/Header/common.h
@@ -3,6 +3,7 @@
 
 #include <CGAL/Polygon_2.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
 
 #include <QPoint>
 #include <QVector>
@@ -13,7 +14,10 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef K::Point_2 Point_2;
+typedef K::Point_3 Point_3;
 typedef std::list<Point_2> Container;
 typedef CGAL::Polygon_2<K, Container> Polygon_2;
+typedef CGAL::Surface_mesh<Point_3> Surface_mesh;
+
 
 #endif

--- a/Header/onepointquery.h
+++ b/Header/onepointquery.h
@@ -34,22 +34,13 @@ class OnePointQuery
 {
 public:
 	OnePointQuery();
-	void setStartingPoint(const QPointF& point);
-	void setQueryPoint(const QPointF& point);
-	void clearPoints();
-	QPointF getStartingPoint() const;
-	QPointF getQueryPoint() const;
-
-	// Check if points are set
-	bool isStartingPointSet() const;
-	bool isQueryPointSet() const;
-
 	bool checkVisibilty(const QPointF& point1, const QPointF& point2, Polygon_2& polygon);
+	bool areEqual(Point_2 a, Point_2 b);
 	void clearTree();
-	void shootRayExtended(const QPointF& point1, const QPointF& point2, Polygon_2& polygon);
+	QPointF shootRayExtended(const QPointF& point1, const QPointF& point2, Polygon_2& polygon);
+	QPointF snapPointInPolygon(const Point_2& query, const Point_2& source, const Polygon_2& polygon);
 	Point_2 convertToCGALPoint(const QPointF& qtPoint);
 	QPointF convertToQTPoint(const Point_2& cgalPoint);
-	Point_2 getIntersection();
 	double calculateFunnelAngle(const QPointF& point1, const QPointF& point2, const QPointF& a, const QPointF& b);
 	QPointF calculateWindowIntersection(const QPointF& pathPoint, const QPointF& windowStart, const QPointF& windowEnd);
 
@@ -65,8 +56,6 @@ public:
 
 	void resetLog();
 
-	void executeOnePointQuery(QPointF& startingPoint, QPointF& queryPoint, Polygon_2& polygon);
-
 	struct QueryResult {
 		bool visibility;
 		QVector<QPointF> pathStartToQuery;
@@ -77,6 +66,8 @@ public:
 		QPointF optimalPoint;
 		QVector<QPointF> optimalPath;
 	};
+
+	void executeOnePointQuery(QPointF& startingPoint, QPointF& queryPoint, Polygon_2& polygon, const Surface_mesh& mesh);
 
 	const QueryResult getResult() const;
 	QLineF calculateWindow(QVector<QPointF>& path, QPointF& queryPoint, Polygon_2& polygon);
@@ -91,7 +82,6 @@ private:
 	bool m_startSelected; // Whether the starting point is set
 	bool m_querySelected; // Whether the first query point is set
 	bool visibilty;       // Whether q is visible from s
-	Point_2 b;
 	AABB_tree tree;
 	std::vector<Segment_2> edges;
 	double calculateAngle(const K::Vector_2& v1, const K::Vector_2& v2);

--- a/Header/polygonwidget.h
+++ b/Header/polygonwidget.h
@@ -69,6 +69,7 @@ private:
     QVector<QPointF> clicks;
     Polygon_2 polygonC;
     QVector<QPointF> polygonQ;
+    Surface_mesh m_mesh;
 
     PolygonGen m_polygonGenHandler;
     OnePointQuery m_onePointHandler;

--- a/Header/shortestpath.h
+++ b/Header/shortestpath.h
@@ -7,7 +7,6 @@
 #include <CGAL/Delaunay_mesh_face_base_2.h>
 #include <CGAL/Delaunay_mesh_size_criteria_2.h>
 #include <CGAL/mark_domain_in_triangulation.h>
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Surface_mesh_shortest_path.h>
 
 #include <boost/lexical_cast.hpp>
@@ -25,7 +24,6 @@ typedef CGAL::Constrained_Delaunay_triangulation_2<K> CDT;
 typedef CDT::Face_handle Face_handle;
 
 // Shortest Path
-typedef CGAL::Surface_mesh<Point_3> Surface_mesh;
 typedef CGAL::Surface_mesh_shortest_path_traits<K, Surface_mesh> Traits;
 typedef CGAL::Surface_mesh_shortest_path<Traits> Surface_mesh_shortest_path;
 typedef Surface_mesh_shortest_path::Face_location Face_location;
@@ -45,21 +43,18 @@ class ShortestPath
 {
 public:
     ShortestPath();
-    void createMesh(const Polygon_2 &polygon);
-    const Surface_mesh &getMesh() const;
+    Surface_mesh createMesh(const Polygon_2 &polygon);
     void clearTree();
-    void clearMesh();
     bool is_point_on_polygon_edge(const Polygon_2& polygon, const Point_2& point);
-    QVector<QPointF> findShortestPath(QPointF source2D, QPointF query2D, const Polygon_2 &polygon);
-    double findShortestPathLength(QPointF source2D, QPointF query2D, const Polygon_2& polygon);
+    QVector<QPointF> findShortestPath(QPointF source2D, QPointF query2D, const Polygon_2 &polygon, const Surface_mesh& mesh);
+    double findShortestPathLength(QPointF source2D, QPointF query2D, const Polygon_2& polygon, const Surface_mesh& mesh);
     Point_2 snapQueryInsidePolygon(QPointF& queryPoint, const Polygon_2& polygon);
     QVector<QPointF> point3VectorToQtVector(std::vector<Point_3>& points);
     const Point_2 &getPenultimate(const std::vector<Point_3> &path, const Polygon_2 &polygon) const;
     QVector<QPointF> reversePath(QVector<QPointF>& path);
-    QPointF getLCA(QPointF& start, QPointF& a, QPointF& b, Polygon_2& polygon);
+    QPointF getLCA(QVector<QPointF>& path1, QVector<QPointF>& path2);
 
 private:
-    Surface_mesh mesh;
     bool pointsSet;
     CDT cdt;
     std::vector<Point_3> points;

--- a/Header/twopointquery.h
+++ b/Header/twopointquery.h
@@ -11,68 +11,93 @@ class TwoPointQuery
 public:
 	TwoPointQuery();
 
+	struct HourglassStruct {
+		QVector<QPointF> hourglassSide1;
+		QVector<QPointF> hourglassSide2;
+		bool isOpen = false;
+	};
+
+	struct FunnelStruct {
+		QVector<QPointF> funnelSideA;
+		QVector<QPointF> funnelSideB;
+	};
+
+	enum FailureCondition { NONE, FUNNEL, HOURGLASS, FUNNEL_HOURGLASS, VISIBILITY };
+
+	struct TangentStruct {
+		FailureCondition failure = NONE;
+		int funnelIntersections = 0;
+		int hourglassIntersections = 0;
+		QVector<QPointF> tangentPath;
+	};
+
+	struct ConcatenatedSideStruct {
+		QVector<QPointF> concatenatedSide;
+		int mFunnelIndex = 0;
+		int mHourglassIndex = 0;
+		QPointF mFunnelPoint;
+		QPointF mHourglassPoint;
+	};
+
+	struct FunnelStar {
+		QVector<QPointF> funnelStarSide1;
+		QVector<QPointF> funnelStarSide2;
+		QPointF m1;
+		QPointF m2;
+		QPointF m3;
+		QPointF m4;
+		int m2Index = 0;
+		int m4Index = 0;
+		bool isRootInFunnel = false;
+		
+	};
+
+	TwoPointQuery::HourglassStruct constructHourglass(QLineF& window1, QLineF& window2, Polygon_2& polygon, Surface_mesh& mesh);
+
 	QVector<QPointF> convertToQT(std::vector<Point_3> points);
 
-	QVector<QPointF> shortestPathToSegment(QPointF start, QLineF segment, Polygon_2& polygon);
+	QVector<QPointF> shortestPathToSegment(QPointF start, QLineF segment, Polygon_2& polygon, Surface_mesh& mesh);
 
 	bool dominateWindowCheck(QLineF window, QVector<QPointF> shortestPath);
 
 	double calculatePathLength(const QVector<QPointF>& path);
 
-	bool hourglassOpen(QVector<QPointF>& hourglassSide1, QVector<QPointF>& hourglassSide2);
+	bool isHourglassOpenCheck(QVector<QPointF>& hourglassSide1, QVector<QPointF>& hourglassSide2);
 
 	QPointF mirrorPoint(const QPointF& point, const QLineF& window);
 
-	QVector<QPointF> concatenateClosed(QVector<QPointF> funnelSide, QVector<QPointF> hourglassSide, QVector<QPointF> tangent);
+	ConcatenatedSideStruct concatenateClosed(QVector<QPointF> funnelSide, QVector<QPointF> hourglassSide, QVector<QPointF> tangent);
+	ConcatenatedSideStruct concatenateOpen1(QVector<QPointF>& funnelSide, QVector<QPointF>& hourglassSide, QVector<QPointF>& tangent);
+	ConcatenatedSideStruct concatenateOpen2(QVector<QPointF>& funnelSide, QVector<QPointF>& hourglassSide, QVector<QPointF>& tangent);
+	FunnelStar concatenateClosedHourglass(QVector<QPointF>& tangent1, QVector<QPointF>& tangent2, QVector<QPointF>& tangent3, QVector<QPointF>& tangent4, FunnelStruct& funnel, HourglassStruct& hourglass);
+	FunnelStar concatenateBlockedOpenHourglass(QVector<QPointF>& tangent2, QVector<QPointF>& tangent3, FunnelStruct& funnel, HourglassStruct& hourglass);
+	FunnelStar concatenateOpenHourglass(QVector<QPointF>& tangent1, QVector<QPointF>& tangent4, FunnelStruct& funnel, HourglassStruct& hourglass);
 
-	QVector<QPointF> concatenateOpen1(QVector<QPointF>& funnelSide, QVector<QPointF>& hourglassSide, QVector<QPointF>& tangent);
-
-	QVector<QPointF> concatenateOpen2(QVector<QPointF>& funnelSide, QVector<QPointF>& hourglassSide, QVector<QPointF>& tangent);
-
-	QPointF getMFunnel();
-
-	QPointF getMHourglass();
-
-	int getFunnelIndex();
-
-	int getHourglassIndex();
 
 	bool searchFirstHalf(QPointF& m, int& mIndex, QVector<QPointF>& concatenatedSide, QPointF& mirrorPoint, QLineF& window2);
 
 	QVector<QPointF> computeOptimalPathQ2(QVector<QPointF>& pathRA2, QVector<QPointF>& pathRB2, QPointF& m1, QPointF& m2, QPointF& m3, QPointF& m4, QLineF& window1, bool searchFirstHalf1, bool searchFirstHalf2);
 
-	void executeTwoPointQuery(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon);
+	void executeTwoPointQuery(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, Polygon_2& polygon, Surface_mesh& mesh);
 
-	void intersectionCase(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, QLineF& window1, QLineF& window2, Polygon_2& polygon);
+	void intersectionCase(QPointF& startingPoint, QPointF& queryPoint1, QPointF& queryPoint2, QLineF& window1, QLineF& window2, Polygon_2& polygon, Surface_mesh& mesh);
 
-	void dominationCase(QPointF& startingPoint, QLineF& window1, QLineF& window2, Polygon_2& polygon);
+	void dominationCase(QPointF& startingPoint, QLineF& window1, QLineF& window2, Polygon_2& polygon, Surface_mesh mesh);
 
-	void computeGeneralCase(QPointF& startingPoint, QLineF& window1, QLineF& window2, Polygon_2& polygon);
+	void computeGeneralCase(QPointF& startingPoint, QLineF& window1, QLineF& window2, Polygon_2& polygon, Surface_mesh& mesh);
+
+	void generalCase(QPointF& startingPoint, QLineF& window1, QLineF& window2, Polygon_2& polygon, Surface_mesh& mesh);
 
 
-	void concatenateClosedHourglass(QVector<QPointF>& tangent1, QVector<QPointF>& tangent2, QVector<QPointF>& tangent3, QVector<QPointF>& tangent4);
+	QVector<QPointF> computeOptimalPathRootInFunnel(QLineF& window1, QLineF& window2, FunnelStar& funnelStar, QVector<QPointF>& pathStartToFunnelRoot);
+	QVector<QPointF> computeOptimalPathRootInHourglass(QLineF& window2, FunnelStar& funnelStar, QVector<QPointF>& pathStartToFunnelRoot);
 
-	void concatenateBlockedOpenHourglass(QVector<QPointF>& tangent2, QVector<QPointF>& tangent3);
-
-	void concatenateOpenHourglass(QVector<QPointF>& tangent1, QVector<QPointF>& tangent4);
-
-	void computeOptimalPathRootInFunnel(QLineF& window1, QLineF& window2);
-
-	void computeOptimalPathRootInHourglass(QLineF& window2);
-
-	void constructHourglass(QLineF& window1, QLineF& window2, Polygon_2& polygon);
-
-	//void generalCase(QLineF& window1, QLineF& window2, Polygon_2& polygon);
-
-	void findTangent(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
-
-	void findTangentEdgeHourglass(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
-
-	void findTangentEdgeFunnel(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
-
-	void findTangentEdgeBoth(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
-
-	void findTangentEdgeCase(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
+	TangentStruct findTangent(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
+	TangentStruct findTangentEdgeHourglass(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
+	bool isTangentEdgeHourglass(const QLineF& line, const QVector<QPointF>& side, const Polygon_2& polygon);
+	TangentStruct findTangentEdgeFunnel(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
+	bool isTangentEdgeFunnel(const QLineF& line, const QVector<QPointF>& side, const Polygon_2& polygon);
+	TangentStruct findTangentEdgeBoth(const QPointF& funnelPoint, const QPointF& hourglassPoint, const QVector<QPointF>& funnelSide, const QVector<QPointF>& hourglassSide, const QLineF& window, Polygon_2& polygon);
 
 	int numberOfIntersections(const QLineF& line, const QVector<QPointF>& side);
 
@@ -85,12 +110,21 @@ public:
 	bool doSegmentsOverlap(const QLineF& line1, const QLineF& line2);
 
 	struct GeneralCaseResult {
+		QPointF funnelRoot;
 		QVector<QPointF> funnelSideA;
 		QVector<QPointF> funnelSideB;
 		QVector<QPointF> hourglassSide1;
 		QVector<QPointF> hourglassSide2;
+		QVector<QPointF> tangent1;
+		QVector<QPointF> tangent2;
+		QVector<QPointF> tangent3;
+		QVector<QPointF> tangent4;
 		QVector<QPointF> concatenatedSide1;
 		QVector<QPointF> concatenatedSide2;
+		QPointF m1;
+		QPointF m2;
+		QPointF m3;
+		QPointF m4;
 		QVector<QPointF> optimalPath;
 		QPointF optimalPoint;
 	};
@@ -109,11 +143,11 @@ public:
 	enum Q2CASE { QNONE, INTERSECTION, DOMINATION, GENERAL };
 
 	struct QueryResult {
-		bool visibility;
+		bool visibility = false;
 		OnePointQuery::QueryResult resultQ1;
 		QLineF window1;
 		QLineF window2;
-		Q2CASE currentCase;
+		Q2CASE currentCase = QNONE;
 	};
 
 	GeneralCaseResult getGeneralCaseResult();
@@ -121,28 +155,24 @@ public:
 	DominationResult getDominationResult();
 	QueryResult getQ2Result();
 
-
-
+	///////////
+	//TEST
+	QLineF line;
+	QLineF firstWindow;
+	QVector<QPointF> funnelSideTest;
+	QVector<QPointF> funnelVecSideTest;
+	QPointF starRoot;
+	QVector<QPointF> PRAT;
+	QVector<QPointF> PRBT;
+	///////////
 
 private:
 	ShortestPath m_shortestPathHandler;
 	OnePointQuery m_onePointHandler;
-	QVector<QPointF> m_tangent;
-
-	enum FailureCondition { NONE, FUNNEL, HOURGLASS, FUNNEL_HOURGLASS, VISIBILITY};
-	FailureCondition failure;
-	int funnelIntersections;
-	int hourglassIntersections;
-
-	QPointF mFunnel;
-	QPointF mHourglass;
-	int mFunnelIndex;
-	int mHourglassIndex;
 
 	OnePointQuery::QueryResult resultQ1;
 
 	Q2CASE currentCase;
-
 
 	GeneralCaseResult resultGeneral;
 
@@ -151,34 +181,6 @@ private:
 	DominationResult resultDomination;
 
 	QueryResult resultQ2;
-
-
-	bool m_isHourglassOpen;
-	QVector<QPointF> hourglassSide1;
-	QVector<QPointF> hourglassSide2;
-
-	QPointF m1;
-	QPointF m2;
-	QPointF m3;
-	QPointF m4;
-
-	bool rootInFunnel1;
-
-	QVector<QPointF> concatenatedSide1;
-	QVector<QPointF> concatenatedSide2;
-
-	int m2Index;
-	int m4Index;
-
-	QPointF rootStar;
-	int rootStarIndex;
-	QVector<QPointF> pathRA2;
-	QVector<QPointF> pathRB2;
-	QVector<QPointF> optimalPath;
-
-	QPointF c;
-
-	void generalCase(QPointF& startingPoint, QLineF& window1, QLineF& window2, Polygon_2& polygon);
 };
 
-#endif // TwoPointQuery_H
+#endif

--- a/Source/mainwindow.cpp
+++ b/Source/mainwindow.cpp
@@ -151,7 +151,7 @@ void MainWindow::setupAuto()
 	intervalSlider->setTickPosition(QSlider::TicksAbove);
 	intervalSlider->setTickInterval(100);
 	intervalSlider->setRange(0, 1000); // Range of epsilon values
-	intervalSlider->setValue(500);    // Default value
+	intervalSlider->setValue(0);    // Default value
 
 	// Create labels for the ticks
 	QHBoxLayout* tickLabelsLayout = createTickLabel();
@@ -371,7 +371,7 @@ void MainWindow::updatePolySelection(PolyMode mode)
 		break;
 	case PICK:
 		polygonModeWidget->setCurrentWidget(givenLayoutWidget);
-		onGivenPolygonChanged(0);
+		onGivenPolygonChanged(3);
 		break;
 	default:
 		break;

--- a/Source/shortestpath.cpp
+++ b/Source/shortestpath.cpp
@@ -5,9 +5,9 @@ ShortestPath::ShortestPath()
 {
 }
 
-void ShortestPath::createMesh(const Polygon_2& polygon)
+Surface_mesh ShortestPath::createMesh(const Polygon_2& polygon)
 {
-	mesh.clear();
+	Surface_mesh mesh;
 	cdt.clear();
 	cdt.insert_constraint(polygon.vertices_begin(), polygon.vertices_end(), true);
 	assert(cdt.is_valid());
@@ -43,19 +43,12 @@ void ShortestPath::createMesh(const Polygon_2& polygon)
 		// Add the triangular face to the mesh
 		mesh.add_face(v0, v1, v2);
 	}
-}
 
-const Surface_mesh& ShortestPath::getMesh() const
-{
 	return mesh;
 }
 
 void ShortestPath::clearTree() {
 	tree.clear();
-}
-
-void ShortestPath::clearMesh() {
-	mesh.clear();
 }
 
 bool ShortestPath::is_point_on_polygon_edge(const Polygon_2& polygon, const Point_2& point) {
@@ -67,7 +60,7 @@ bool ShortestPath::is_point_on_polygon_edge(const Polygon_2& polygon, const Poin
 	return false;
 }
 
-QVector<QPointF> ShortestPath::findShortestPath(QPointF source2D, QPointF query2D, const Polygon_2& polygon)
+QVector<QPointF> ShortestPath::findShortestPath(QPointF source2D, QPointF query2D, const Polygon_2& polygon, const Surface_mesh& mesh)
 {
 	points.clear();
 	shortestPath.clear();
@@ -76,7 +69,7 @@ QVector<QPointF> ShortestPath::findShortestPath(QPointF source2D, QPointF query2
 		createMesh(polygon);
 	}
 
-	Point_2 query2 = snapQueryInsidePolygon(query2D, polygon);
+	Point_2 query2 = Point_2(query2D.x(), query2D.y());
 
 	// construct a shortest path query object and add a source point
 	Surface_mesh_shortest_path shortest_paths(mesh);
@@ -111,13 +104,14 @@ QVector<QPointF> ShortestPath::findShortestPath(QPointF source2D, QPointF query2
 	return reversePath(shortestPathQt);
 }
 
-double ShortestPath::findShortestPathLength(QPointF source2D, QPointF query2D, const Polygon_2& polygon)
+double ShortestPath::findShortestPathLength(QPointF source2D, QPointF query2D, const Polygon_2& polygon, const Surface_mesh& mesh)
 {
 	if (mesh.is_empty()) {
 		createMesh(polygon);
 	}
 
-	Point_2 query2 = snapQueryInsidePolygon(query2D, polygon);
+	//Point_2 query2 = snapQueryInsidePolygon(query2D, polygon);
+	Point_2 query2 = Point_2(query2D.x(), query2D.y());
 
 	// Create shortest path query object and add a source point
 	Surface_mesh_shortest_path shortest_paths(mesh);
@@ -137,6 +131,7 @@ double ShortestPath::findShortestPathLength(QPointF source2D, QPointF query2D, c
 	return shortest_paths.shortest_distance_to_source_points(query_loc.first, query_loc.second).first;
 }
 
+// TODO: remove me
 Point_2 ShortestPath::snapQueryInsidePolygon(QPointF& queryPoint, const Polygon_2& polygon) {
 	Point_2 query = Point_2(queryPoint.x(), queryPoint.y());
 
@@ -200,11 +195,8 @@ QVector<QPointF> ShortestPath::reversePath(QVector<QPointF>& path)
 	return path;
 }
 
-QPointF ShortestPath::getLCA(QPointF& start, QPointF& a, QPointF& b, Polygon_2& polygon)
+QPointF ShortestPath::getLCA(QVector<QPointF>& path1, QVector<QPointF>& path2)
 {
-	QVector<QPointF> path1 = findShortestPath(start, a, polygon);
-	QVector<QPointF> path2 = findShortestPath(start, b, polygon);
-
 	QPointF lca;
 
 	// Iterate over both paths until they diverge


### PR DESCRIPTION
- fixed the issue where approx query would only look at the windows in chronological order
- removed global variables in TwoPointQuery and replaced them passes through arguments
- fixed the issue where the calculations would not work anymore when regenrating the polygon
- made the previous fix for shortest path calculations more consistent
- fixed the issue of visibility calculations where equal points would not be seen as equal
- fixed a lot of cases in TwoPointQuery and added some more edge case calculations