### PR TITLE
binary search for |Q|=1 was updated

### DIFF
--- a/Header/onepointquery.h
+++ b/Header/onepointquery.h
@@ -50,7 +50,9 @@ public:
 
 	QPointF getVertexPerpendicularToC();
 
-	int binarySearchByAngle(QVector<QPointF>& path, QPointF& a, QPointF& b);
+	int binarySearchByAngleASide(QVector<QPointF>& path, QPointF& a, QPointF& b);
+
+	int binarySearchByAngleBSide(QVector<QPointF>& path, QPointF& a, QPointF& b);
 
 	QString getLog();
 

--- a/Source/generalcase.cpp
+++ b/Source/generalcase.cpp
@@ -157,7 +157,9 @@ GeneralCase::TangentStruct GeneralCase::findTangent(const QPointF& funnelPoint,
 		Polygon_2 bounds;
 		bounds.push_back(Point_2(hourglassSide.first().x(), hourglassSide.first().y()));
 		bounds.push_back(Point_2(hourglassSide.begin()[1].x(), hourglassSide.begin()[1].y()));
-		bounds.push_back(Point_2(hourglassSideHelper.begin()[1].x(), hourglassSideHelper.begin()[1].y()));
+		if (hourglassSide.begin()[1] != hourglassSideHelper.begin()[1]) {
+			bounds.push_back(Point_2(hourglassSideHelper.begin()[1].x(), hourglassSideHelper.begin()[1].y()));
+		}
 		bounds.push_back(Point_2(hourglassSideHelper.first().x(), hourglassSideHelper.first().y()));
 		boundTest = bounds;
 
@@ -716,7 +718,7 @@ QPointF GeneralCase::computeOptimalPoint(FunnelStar& funnelStar, QLineF& window1
 
 	if (anglem1 > 90)
 	{
-		int vertex = m_onePointHandler.binarySearchByAngle(modifiedSide1, a2, b2);
+		int vertex = m_onePointHandler.binarySearchByAngleASide(modifiedSide1, a2, b2);
 		int v = (modifiedSide1.size() - 1) - vertex; // root would be lowest, but needs to be highest
 		std::cout << "c is foot from v" << v << "\n";
 		onPathRootToA = true;
@@ -726,7 +728,7 @@ QPointF GeneralCase::computeOptimalPoint(FunnelStar& funnelStar, QLineF& window1
 	}
 	else
 	{
-		int vertex = m_onePointHandler.binarySearchByAngle(modifiedSide2, a2, b2);
+		int vertex = m_onePointHandler.binarySearchByAngleBSide(modifiedSide2, a2, b2);
 		int v = vertex + (modifiedSide2.size() - 1);
 		std::cout << "c is foot from v" << v << "\n";
 		onPathRootToA = false;

--- a/Source/onepointquery.cpp
+++ b/Source/onepointquery.cpp
@@ -303,10 +303,10 @@ QPointF OnePointQuery::computeOptimalPoint(QVector<QPointF>& pathRA, QVector<QPo
 
 	if (anglem1 > 90)
 	{
-		int vertex = binarySearchByAngle(pathRA, a, b);
+		int vertex = binarySearchByAngleASide(pathRA, a, b);
 		int v = (pathRA.size() - 1) - vertex; // root would be lowest, but needs to be highest
 
-		logQ1 = "c is at the foot of the perpendicular from v" + v;
+		//logQ1 = "c is at the foot of the perpendicular from v" + v;
 		std::cout << "c is foot from v" << v << "\n";
 		onPathRootToA = true;
 		vertexPerpendicularToC = pathRA[vertex];
@@ -314,7 +314,7 @@ QPointF OnePointQuery::computeOptimalPoint(QVector<QPointF>& pathRA, QVector<QPo
 	}
 	else
 	{
-		int vertex = binarySearchByAngle(pathRB, a, b);
+		int vertex = binarySearchByAngleBSide(pathRB, a, b);
 		int v = vertex + (pathRA.size() - 1);
 		logQ1 = "c is at the foot of the perpendicular from v" + v;
 		std::cout << "c is foot from v" << v << "\n";
@@ -332,33 +332,60 @@ QPointF OnePointQuery::getVertexPerpendicularToC() {
 	return vertexPerpendicularToC;
 }
 
-int OnePointQuery::binarySearchByAngle(QVector<QPointF>& path, QPointF& a, QPointF& b)
+int OnePointQuery::binarySearchByAngleASide(QVector<QPointF>& path, QPointF& a, QPointF& b)
 {
 	int left = 0;
 	int right = path.size() - 1;
-	int mid = left + (right - left) / 2;
+	int mid = 0;
+	double theta_mid = 0;
+	// right - left > 1
 
 	while (right - left > 1)
-	{ // Continue until the interval is narrowed down to two successive vertices
-		mid = left + (right - left) / 2;
-
-		// Compute angle at the midpoint
+	{
+		mid = (right + left + 1) / 2;
 		double theta_mid = calculateFunnelAngle(path[mid - 1], path[mid], a, b);
 
-		// Use the angle to decide search direction
 		if (theta_mid > 90)
 		{
-			// Move to the left side
-			right = mid;
-		}
-		else
-		{
-			// Move to the right side
 			left = mid;
 		}
+		else if (theta_mid < 90)
+		{
+			right = mid;
+		}
+		else {
+			return mid;
+		}
 	}
+	return left;
+}
 
-	return mid-1; // Return the index of the narrowed-down interval's start vertex
+int OnePointQuery::binarySearchByAngleBSide(QVector<QPointF>& path, QPointF& a, QPointF& b)
+{
+	int left = 0;
+	int right = path.size() - 1;
+	int mid = 0;
+	double theta_mid = 0;
+	// right - left > 1
+
+	while (right - left > 1)
+	{
+		mid = (right + left + 1) / 2;
+		double theta_mid = calculateFunnelAngle(path[mid - 1], path[mid], a, b);
+
+		if (theta_mid > 90)
+		{
+			right = mid;
+		}
+		else if (theta_mid < 90)
+		{
+			left = mid;
+		}
+		else {
+			return mid;
+		}
+	}
+	return left;
 }
 
 QString OnePointQuery::getLog()

--- a/Source/polygongen.cpp
+++ b/Source/polygongen.cpp
@@ -141,7 +141,6 @@ Polygon_2 PolygonGen::exampleFour() const
     return p;
 }
 
-/*
 Polygon_2 PolygonGen::exampleFive() const
 {
     Polygon_2 p;
@@ -164,72 +163,54 @@ Polygon_2 PolygonGen::exampleFive() const
 
     return p;
 }
-*/
 
+
+/*
 Polygon_2 PolygonGen::exampleFive() const
 {
     Polygon_2 p;
-    p.push_back(Point_2(111, -169));
-    p.push_back(Point_2(41, -131));
-    p.push_back(Point_2(43, -158));
-    p.push_back(Point_2(201, -236));
-    p.push_back(Point_2(222, -220));
-    p.push_back(Point_2(216, 229));
-    p.push_back(Point_2(190, 206));
-    p.push_back(Point_2(161, 227));
-    p.push_back(Point_2(176, 240));
-    p.push_back(Point_2(-26, 249));
-    p.push_back(Point_2(-132, 246));
-    p.push_back(Point_2(-137, 228));
-    p.push_back(Point_2(-178, 114));
-    p.push_back(Point_2(-155, 241));
-    p.push_back(Point_2(-198, 183));
-    p.push_back(Point_2(-222, 120));
-    p.push_back(Point_2(-187, -26));
-    p.push_back(Point_2(-71, -49));
-    p.push_back(Point_2(-66, -75));
-    p.push_back(Point_2(-91, -192));
-    p.push_back(Point_2(-202, -70));
-    p.push_back(Point_2(-247, -216));
-    p.push_back(Point_2(-186, -93));
-    p.push_back(Point_2(-151, -245));
-    p.push_back(Point_2(53, -241));
-    p.push_back(Point_2(-96, -233));
-    p.push_back(Point_2(-13, -201));
-    p.push_back(Point_2(76, -23));
-    p.push_back(Point_2(75, 31));
-    p.push_back(Point_2(11, -37));
-    p.push_back(Point_2(-80, -30));
-    p.push_back(Point_2(-58, 94));
-    p.push_back(Point_2(-79, 197));
-    p.push_back(Point_2(-64, 197));
-    p.push_back(Point_2(37, 219));
-    p.push_back(Point_2(58, 211));
-    p.push_back(Point_2(156, 223));
-    p.push_back(Point_2(102, 214));
-    p.push_back(Point_2(-14, 171));
-    p.push_back(Point_2(-24, 134));
-    p.push_back(Point_2(114, 135));
-    p.push_back(Point_2(83, 112));
-    p.push_back(Point_2(120, 134));
-    p.push_back(Point_2(193, 127));
-    p.push_back(Point_2(128, 112));
-    p.push_back(Point_2(112, 94));
-    p.push_back(Point_2(56, 119));
-    p.push_back(Point_2(38, 91));
-    p.push_back(Point_2(-39, 100));
-    p.push_back(Point_2(80, 74));
-    p.push_back(Point_2(89, -51));
-    p.push_back(Point_2(152, 5));
-    p.push_back(Point_2(160, 21));
-    p.push_back(Point_2(204, 144));
-    p.push_back(Point_2(200, 4));
-    p.push_back(Point_2(99, -76));
-    p.push_back(Point_2(35, -113));
-    p.push_back(Point_2(117, -154));
-    p.push_back(Point_2(132, -140));
-    p.push_back(Point_2(185, -196));
+    p.push_back(Point_2(161, -152));
+    p.push_back(Point_2(99, -188));
+    p.push_back(Point_2(34, -185));
+    p.push_back(Point_2(-58, -239));
+    p.push_back(Point_2(106, -221));
+    p.push_back(Point_2(176, -182));
+    p.push_back(Point_2(198, -118));
+    p.push_back(Point_2(222, -34));
+    p.push_back(Point_2(240, 49));
+    p.push_back(Point_2(215, 21));
+    p.push_back(Point_2(143, 136));
+    p.push_back(Point_2(215, 177));
+    p.push_back(Point_2(153, 160));
+    p.push_back(Point_2(43, 234));
+    p.push_back(Point_2(45, 84));
+    p.push_back(Point_2(159, 42));
+    p.push_back(Point_2(91, -51));
+    p.push_back(Point_2(72, 14));
+    p.push_back(Point_2(9, -115));
+    p.push_back(Point_2(-110, 158));
+    p.push_back(Point_2(-103, 188));
+    p.push_back(Point_2(-146, 216));
+    p.push_back(Point_2(-232, 175));
+    p.push_back(Point_2(-149, 192));
+    p.push_back(Point_2(-100, -57));
+    p.push_back(Point_2(-47, -96));
+    p.push_back(Point_2(-77, -119));
+    p.push_back(Point_2(-139, -124));
+    p.push_back(Point_2(-221, 59));
+    p.push_back(Point_2(-166, -65));
+    p.push_back(Point_2(-235, 47));
+    p.push_back(Point_2(-206, -5));
+    p.push_back(Point_2(-208, -209));
+    p.push_back(Point_2(-218, -239));
+    p.push_back(Point_2(-194, -204));
+    p.push_back(Point_2(-131, -143));
+    p.push_back(Point_2(-96, -161));
+    p.push_back(Point_2(-74, -223));
+    p.push_back(Point_2(52, -149));
+    p.push_back(Point_2(173, -87));
 
     return p;
 }
+*/
 

--- a/Source/polygonwidget.cpp
+++ b/Source/polygonwidget.cpp
@@ -474,15 +474,19 @@ void PolygonWidget::paintEvent(QPaintEvent* event)
 	painter.setPen(Qt::black);
 	painter.setBrush(Qt::black);
 
-	fixedPoints = true;
+	//fixedPoints = true;
 	if (fixedPoints) {
 		//startingPoint = QPointF(47, -119);
 		//queryPoint1 = QPointF(275, -98);
 
 		// one point query test
-		/*
 		startingPoint = QPointF(-218, 88);
 		queryPoint1 = QPointF(307, -80);
+
+		// one point query not working
+		/*
+		startingPoint = QPointF(-130, 166);
+		queryPoint1 = QPointF(-184, -121);
 		*/
 
 		//closed hourglass
@@ -494,10 +498,12 @@ void PolygonWidget::paintEvent(QPaintEvent* event)
 
 
 		// opern hourglass
+		/*
 		startingPoint = QPointF(204, 162);
 		queryPoint1 = QPointF(-111, 10);
 		queryPoint2 = QPointF(-154, 114);
 		update();
+		*/
 		//setFixedPoints(startingPoint = QPointF(205, 169), queryPoint1 = QPointF(-105, -5), queryPoint2 = QPointF(-157, 108));
 	}
 


### PR DESCRIPTION
The binary search on the shortest path from root to a  can not be treated the same as the search on the path from root to b
-> search was split into two functions